### PR TITLE
remove SVGFonts in favour of plain SVG text nodes

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -37,7 +37,6 @@ dependencies:
 - pretty-simple
 - split >= 0.2.3.4
 - svg-builder
-- SVGFonts
 - text
 - transformers >= 0.5.6.2
 - unicode-transforms >= 0.4.0.1

--- a/src/XbarDiagram.hs
+++ b/src/XbarDiagram.hs
@@ -7,8 +7,8 @@ module XbarDiagram where
 import Data.Text (Text)
 import qualified Data.Text as T
 import Diagrams.Prelude
+import qualified Diagrams.TwoD.Text as TD
 import Diagrams.Backend.SVG
-import Graphics.SVGFonts
 import Data.Colour.RGBSpace
 import Data.Colour.RGBSpace.HSL
 import Debug.Trace
@@ -52,9 +52,10 @@ toa color height t =
     let
         str = if t == "" then "∅" else T.unpack t
         color' = if color == rui && t == "" then discordBg else color
-        d = stroke (textSVG str height) # fc color' # lw none # centerX
+        d = TD.text str # TD.font "Linux Libertine O" # TD.fontSizeL height # fc color' # lw none # centerX
+        strut' = strut $ flip V2 height $ height / 2 * (fromIntegral (length str))
     in
-        d <> boundingRect (d # frame 0.2) # lcA transparent
+        d <> boundingRect (d `atop` strut' # frame 0.2) # lcA transparent
 
 xbarToDiagram :: (Text -> Text) -> (Xbar, [Movement]) -> Diagram B
 xbarToDiagram gloss (xbar,movements) =

--- a/zugai.cabal
+++ b/zugai.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.34.7.
 --
 -- see: https://github.com/sol/hpack
 
@@ -44,8 +44,7 @@ library
   default-extensions:
       DeriveFunctor FlexibleInstances ImportQualifiedPost OverloadedStrings
   build-depends:
-      SVGFonts
-    , base >=4.7 && <5
+      base >=4.7 && <5
     , bytestring >=0.10.12
     , bytestring-trie >=0.2.7
     , colour >=2.3.6
@@ -75,8 +74,7 @@ executable zugai-exe
       app
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      SVGFonts
-    , base >=4.7 && <5
+      base >=4.7 && <5
     , bytestring >=0.10.12
     , bytestring-trie >=0.2.7
     , colour >=2.3.6
@@ -110,8 +108,7 @@ test-suite zugai-test
       OverloadedStrings
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      SVGFonts
-    , base >=4.7 && <5
+      base >=4.7 && <5
     , bytestring >=0.10.12
     , bytestring-trie >=0.2.7
     , colour >=2.3.6


### PR DESCRIPTION
advantages:
- we can do all kinds of styling on the text and there are no longer text paths that'd weigh down on the file size
disadvantages:
- whatever machine is rendering the svg needs to have the correct font installed (no biggie, though - the diagram should look okay even if we're resorting to a fallback font)
- [the documentation says](https://diagrams.github.io/haddock/diagrams-lib/Diagrams-TwoD-Text.html#v:text) "text nodes take up no space" so I've had to fake spacing (text width and height) with a strut object